### PR TITLE
[project] RPC のビルド完了後 Client ディレクトリに DLL をコピーするようにした

### DIFF
--- a/RPC/RPC.csproj
+++ b/RPC/RPC.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -35,4 +35,7 @@
     <Compile Include="RPC.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Target Name="AfterBuild">
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(SolutionDir)../Client/Assets/Plugins" ContinueOnError="true" />
+  </Target>
 </Project>


### PR DESCRIPTION
コピー先 `Client/Assets/Plugins/`

ビルド設定（ `Debug` , `Release` ）を問わず、ビルドに成功したらコピーします。
基本的に `Release` でしか使わないと思うので、最初だけ設定の確認が必要になると思います。
