### PR TITLE
[2017-latter]第4回実習: 位置を同期できるようにし、ほかプレイヤーを表示できる

### DIFF
--- a/Client/Assets/RollingBall.unity
+++ b/Client/Assets/RollingBall.unity
@@ -743,6 +743,8 @@ MonoBehaviour:
   connectAddress: ws://192.168.17.100:5678
   playerPrefab: {fileID: 1000010242128840, guid: b7ee01bb7113a428d83cd4c2b2dcff8f,
     type: 2}
+  otherPlayerPrefab: {fileID: 1000013530691402, guid: 8da97395e89154d00aeaf2c9abf021e2,
+    type: 2}
 --- !u!4 &2134770747
 Transform:
   m_ObjectHideFlags: 0

--- a/Client/Assets/Scripts/MainController.cs
+++ b/Client/Assets/Scripts/MainController.cs
@@ -11,6 +11,8 @@ public class MainController : MonoBehaviour
 
     [SerializeField]
     GameObject playerPrefab;
+    [SerializeField]
+    GameObject otherPlayerPrefab;
 
     GameObject playerObj;
     Vector3 previousPlayerObjPosition; // 前フレームでの位置

--- a/Client/Assets/Scripts/MainController.cs
+++ b/Client/Assets/Scripts/MainController.cs
@@ -13,6 +13,7 @@ public class MainController : MonoBehaviour
     GameObject playerPrefab;
 
     GameObject playerObj;
+    Vector3 previousPlayerObjPosition; // 前フレームでの位置
     int playerId;
 
     void Start()
@@ -67,6 +68,7 @@ public class MainController : MonoBehaviour
 
     void Update()
     {
+        UpdatePosition();
     }
 
     void OnDestroy()
@@ -89,5 +91,22 @@ public class MainController : MonoBehaviour
         playerId = response.Id;
         Debug.Log(playerId);
         playerObj = Instantiate(playerPrefab, new Vector3(0.0f, 0.5f, 0.0f), Quaternion.identity) as GameObject;
+    }
+
+    void UpdatePosition()
+    {
+        if (playerObj == null) return;
+
+        var currentPlayerPosition = playerObj.transform.position;
+        if (currentPlayerPosition == previousPlayerObjPosition) return;
+
+        Debug.Log(">> Update");
+
+        previousPlayerObjPosition = currentPlayerPosition;
+
+        var rpcPosition = new RPC.Position(currentPlayerPosition.x, currentPlayerPosition.y, currentPlayerPosition.z);
+        var jsonMessage = JsonUtility.ToJson(new RPC.PlayerUpdate(new RPC.PlayerUpdatePayload(playerId, rpcPosition)));
+        Debug.Log(jsonMessage);
+        webSocket.Send(jsonMessage);
     }
 }


### PR DESCRIPTION
- [client] サーバーにプレイヤー位置を送信
  - 動かしてみる
    - サーバーログ、unityのconsoleログに位置情報が流れていることを確認する
    - プレイヤーを動かしたら、サーバーにその位置情報が伝えられる。それを別clientに伝えられれば位置情報が同期できるようになる
- [client] 他のプレイヤー生成の準備
  - `playerPrefab`と同様に`otherPlayerPrefab`変数を用意
  - `otherPlayerPrefab`に赤い箱のprefabをさす
- [client] 他プレイヤーの同期
  - Dictionary, C++のmap, rubyでhash, 連想配列
    - https://qiita.com/dico_leque/items/86fc0e48f827c3c08f4e
  - 動かしてみる
    - exeをビルドする。ビルドしたexeとunityでプレイする
        - build settings -> Add Open Scenes -> Build And Run
    - 他人のサーバーに繋いでみる
- 時間があれば
  - server, rpcのコード読む
    - GameModelのOnPing, OnLoignはrequest受け取ってその場でsendToでresponseを返している
    - GameModelのOnPlayerUpdateはserver側のplayer位置を更新するだけ
    - Syncで各クライアントに通知される

